### PR TITLE
generate md5 and sha1 formatting password from plaintext

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -3,7 +3,9 @@ package auth
 import "encoding/base64"
 import "crypto/md5"
 import "crypto/rand"
+import "crypto/sha1"
 import "fmt"
+import mrand "math/rand"
 
 /*
  Return a random 16-byte base64 alphabet string
@@ -27,4 +29,26 @@ func H(data string) string {
 	digest := md5.New()
 	digest.Write([]byte(data))
 	return fmt.Sprintf("%x", digest.Sum(nil))
+}
+
+/*
+Generate MD5 formatting password: $magic$salt$hash from plaintext
+*/
+func GenMD5Password(plaintext string) string {
+	salt := RandomKey()
+	magic := fmt.Sprintf("$%d$", mrand.Intn(100))
+	passwd := MD5Crypt([]byte(plaintext), []byte(salt), []byte(magic))
+	return string(passwd)
+}
+
+/*
+Generate SHA1 formating password:{SHA}hash from plaintext
+*/
+func GenSHAPassword(plaintext string) string {
+	h := sha1.New()
+	h.Write([]byte(plaintext))
+	bs := h.Sum(nil)
+	passwd := base64.StdEncoding.EncodeToString(bs)
+	return "{SHA}" + passwd
+
 }

--- a/misc_test.go
+++ b/misc_test.go
@@ -1,6 +1,8 @@
 package auth
 
 import "testing"
+import "encoding/base64"
+import "crypto/sha1"
 
 func TestH(t *testing.T) {
 	const hello = "Hello, world!"
@@ -8,5 +10,27 @@ func TestH(t *testing.T) {
 	h := H(hello)
 	if h != hello_md5 {
 		t.Fatal("Incorrect digest for test string:", h, "instead of", hello_md5)
+	}
+}
+
+func TestGenMD5Password(t *testing.T) {
+	const plaintext = "Hello, word!"
+	passwd := GenMD5Password(plaintext)
+	e := NewMD5Entry(passwd)
+	if e == nil {
+		t.Fatal("Invalid md5 formatting password:", passwd)
+	}
+	if passwd != string(MD5Crypt([]byte(plaintext), e.Salt, e.Magic)) {
+		t.Fatal("Incorrect md5 formatting password:", passwd, "can't match with:", plaintext)
+	}
+}
+
+func TestGenSHAPassword(t *testing.T) {
+	const plaintext = "Hello, word!"
+	passwd := GenSHAPassword(plaintext)
+	d := sha1.New()
+	d.Write([]byte(plaintext))
+	if passwd[5:] != base64.StdEncoding.EncodeToString(d.Sum(nil)) {
+		t.Fatal("Incorrect sha1 formatting password:", passwd, "can't match with:", plaintext)
 	}
 }


### PR DESCRIPTION
When i beginning read the source code of go-http-auth, I spent a long time to find out how the password `:$1$dlPL2MqE$oQmn16q49SqdmhenQuNgs1` of "hello" was generated in example/basic.go . I can't find any explain in document and any demo code.  
So, I implemented the function of generate md5 and sha1 formatting password from plaintext. And i believe these two functions is useful when writing the function  `func  Secret(user, realm string) string`, especially the raw password may be changed.
