### PR TITLE
Adds request to secrets type.

### DIFF
--- a/basic.go
+++ b/basic.go
@@ -33,7 +33,7 @@ func (a *BasicAuth) CheckAuth(r *http.Request) string {
 	if len(pair) != 2 {
 		return ""
 	}
-	passwd := a.Secrets(pair[0], a.Realm)
+	passwd := a.Secrets(r, pair[0], a.Realm)
 	if passwd == "" {
 		return ""
 	}

--- a/digest.go
+++ b/digest.go
@@ -22,7 +22,7 @@ type DigestAuth struct {
 	Secrets          SecretProvider
 	PlainTextSecrets bool
 
-	/* 
+	/*
 	 Approximate size of Client's Cache. When actual number of
 	 tracked client nonces exceeds
 	 ClientCacheSize+ClientCacheTolerance, ClientCacheTolerance*2
@@ -108,7 +108,7 @@ func DigestAuthParams(r *http.Request) map[string]string {
 	return result
 }
 
-/* 
+/*
  Check if request contains valid authentication data. Returns a pair
  of username, authinfo where username is the name of the authenticated
  user or an empty string and authinfo is the contents for the optional
@@ -136,7 +136,7 @@ func (da *DigestAuth) CheckAuth(r *http.Request) (username string, authinfo *str
 		return
 	}
 
-	HA1 := da.Secrets(auth["username"], da.Realm)
+	HA1 := da.Secrets(r, auth["username"], da.Realm)
 	if da.PlainTextSecrets {
 		HA1 = H(auth["username"] + ":" + da.Realm + ":" + HA1)
 	}
@@ -178,7 +178,7 @@ func (da *DigestAuth) CheckAuth(r *http.Request) (username string, authinfo *str
 const DefaultClientCacheSize = 1000
 const DefaultClientCacheTolerance = 100
 
-/* 
+/*
  Wrap returns an Authenticator which uses HTTP Digest
  authentication. Arguments:
 
@@ -201,7 +201,7 @@ func (a *DigestAuth) Wrap(wrapped AuthenticatedHandlerFunc) http.HandlerFunc {
 	}
 }
 
-/* 
+/*
  JustCheck returns function which converts an http.HandlerFunc into a
  http.HandlerFunc which requires authentication. Username is passed as
  an extra X-Authenticated-Username header.

--- a/users_test.go
+++ b/users_test.go
@@ -6,15 +6,15 @@ import (
 
 func TestHtdigestFile(t *testing.T) {
 	secrets := HtdigestFileProvider("test.htdigest")
-	digest := secrets("test", "example.com")
+	digest := secrets(nil, "test", "example.com")
 	if digest != "aa78524fceb0e50fd8ca96dd818b8cf9" {
 		t.Fatal("Incorrect digest for test user:", digest)
 	}
-	digest = secrets("test", "example1.com")
+	digest = secrets(nil, "test", "example1.com")
 	if digest != "" {
 		t.Fatal("Got digest for user in non-existant realm:", digest)
 	}
-	digest = secrets("test1", "example.com")
+	digest = secrets(nil, "test1", "example.com")
 	if digest != "" {
 		t.Fatal("Got digest for non-existant user:", digest)
 	}
@@ -22,11 +22,11 @@ func TestHtdigestFile(t *testing.T) {
 
 func TestHtpasswdFile(t *testing.T) {
 	secrets := HtpasswdFileProvider("test.htpasswd")
-	passwd := secrets("test", "blah")
+	passwd := secrets(nil, "test", "blah")
 	if passwd != "{SHA}qvTGHdzF6KLavt4PO0gs2a6pQ00=" {
 		t.Fatal("Incorrect passwd for test user:", passwd)
 	}
-	passwd = secrets("test3", "blah")
+	passwd = secrets(nil, "test3", "blah")
 	if passwd != "" {
 		t.Fatal("Got passwd for non-existant user:", passwd)
 	}


### PR DESCRIPTION
This adds `*http.Request` to the SecretProvider to allow for more robust authentication, for instance, storage in the appengine datastore, which requires the request to get a context.
