### PR TITLE
fixes abbot/go-http-auth#22

### DIFF
--- a/digest.go
+++ b/digest.go
@@ -103,15 +103,7 @@ func DigestAuthParams(r *http.Request) map[string]string {
 		return nil
 	}
 
-	result := map[string]string{}
-	for _, kv := range strings.Split(s[1], ",") {
-		parts := strings.SplitN(kv, "=", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		result[strings.Trim(parts[0], "\" ")] = strings.Trim(parts[1], "\" ")
-	}
-	return result
+	return ParsePairs(s[1])
 }
 
 /*

--- a/digest_test.go
+++ b/digest_test.go
@@ -1,8 +1,10 @@
 package auth
 
 import (
+	"bufio"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 )
@@ -54,4 +56,24 @@ func TestAuthDigest(t *testing.T) {
 	if u, _ := da.CheckAuth(r); u != "test" {
 		t.Fatal("empty auth for valid request in subpath")
 	}
+}
+
+func TestDigestAuthParams(t *testing.T) {
+	body := `GET http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700,400italic,700italic|Source+Code+Pro HTTP/1.1
+Host: fonts.googleapis.com
+User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:43.0) Gecko/20100101 Firefox/43.0
+Accept: text/css,/;q=0.1
+Accept-Language: en-US,en;q=0.5
+Accept-Encoding: gzip, deflate
+Referer: http://elm-lang.org/assets/style.css
+Authorization: Digest username="test", realm="", nonce="FRPnGdb8lvM1UHhi", uri="/css?family=Source+Sans+Pro:400,700,400italic,700italic|Source+Code+Pro", algorithm=MD5, response="fdcdd78e5b306ffed343d0ec3967f2e5", opaque="lEgVjogmIar2fg/t", qop=auth, nc=00000001, cnonce="e76b05db27a3b323"
+Connection: keep-alive
+
+`
+	req, _ := http.ReadRequest(bufio.NewReader(strings.NewReader(body)))
+	params := DigestAuthParams(req)
+	if params["uri"] != "/css?family=Source+Sans+Pro:400,700,400italic,700italic|Source+Code+Pro" {
+		t.Fatal("failed to parse uri with embedded commas")
+	}
+
 }

--- a/misc.go
+++ b/misc.go
@@ -1,9 +1,13 @@
 package auth
 
-import "encoding/base64"
-import "crypto/md5"
-import "crypto/rand"
-import "fmt"
+import (
+	"bytes"
+	"crypto/md5"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"strings"
+)
 
 /*
  Return a random 16-byte base64 alphabet string
@@ -27,4 +31,70 @@ func H(data string) string {
 	digest := md5.New()
 	digest.Write([]byte(data))
 	return fmt.Sprintf("%x", digest.Sum(nil))
+}
+
+/*
+ ParseList parses a comma-separated list of values as described by RFC 2068.
+ which was itself ported from urllib2.parse_http_list, from the Python standard library.
+ Lifted from https://code.google.com/p/gorilla/source/browse/http/parser/parser.go
+*/
+func ParseList(value string) []string {
+	var list []string
+	var escape, quote bool
+	b := new(bytes.Buffer)
+	for _, r := range value {
+		if escape {
+			b.WriteRune(r)
+			escape = false
+			continue
+		}
+		if quote {
+			if r == '\\' {
+				escape = true
+				continue
+			} else if r == '"' {
+				quote = false
+			}
+			b.WriteRune(r)
+			continue
+		}
+		if r == ',' {
+			list = append(list, strings.TrimSpace(b.String()))
+			b.Reset()
+			continue
+		}
+		if r == '"' {
+			quote = true
+		}
+		b.WriteRune(r)
+	}
+	// Append last part.
+	if s := b.String(); s != "" {
+		list = append(list, strings.TrimSpace(s))
+	}
+	return list
+}
+
+/*
+ ParsePairs extracts key/value pairs from a comma-separated list of values as
+ described by RFC 2068.
+ The resulting values are unquoted. If a value doesn't contain a "=", the
+ key is the value itself and the value is an empty string.
+ Lifted from https://code.google.com/p/gorilla/source/browse/http/parser/parser.go
+*/
+func ParsePairs(value string) map[string]string {
+	m := make(map[string]string)
+	for _, pair := range ParseList(strings.TrimSpace(value)) {
+		if i := strings.Index(pair, "="); i < 0 {
+			m[pair] = ""
+		} else {
+			v := pair[i+1:]
+			if v[0] == '"' && v[len(v)-1] == '"' {
+				// Unquote it.
+				v = v[1 : len(v)-1]
+			}
+			m[pair[:i]] = v
+		}
+	}
+	return m
 }

--- a/misc_test.go
+++ b/misc_test.go
@@ -1,6 +1,10 @@
 package auth
 
-import "testing"
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
 
 func TestH(t *testing.T) {
 	const hello = "Hello, world!"
@@ -9,4 +13,29 @@ func TestH(t *testing.T) {
 	if h != hello_md5 {
 		t.Fatal("Incorrect digest for test string:", h, "instead of", hello_md5)
 	}
+}
+
+func TestParsePairs(t *testing.T) {
+	const header = `username="test", realm="", nonce="FRPnGdb8lvM1UHhi", uri="/css?family=Source+Sans+Pro:400,700,400italic,700italic|Source+Code+Pro", algorithm=MD5, response="fdcdd78e5b306ffed343d0ec3967f2e5", opaque="lEgVjogmIar2fg/t", qop=auth, nc=00000001, cnonce="e76b05db27a3b323"`
+
+	expected := map[string]string{
+		"username":  "test",
+		"realm":     "",
+		"nonce":     "FRPnGdb8lvM1UHhi",
+		"uri":       "/css?family=Source+Sans+Pro:400,700,400italic,700italic|Source+Code+Pro",
+		"algorithm": "MD5",
+		"response":  "fdcdd78e5b306ffed343d0ec3967f2e5",
+		"opaque":    "lEgVjogmIar2fg/t",
+		"qop":       "auth",
+		"nc":        "00000001",
+		"cnonce":    "e76b05db27a3b323",
+	}
+
+	res := ParsePairs(header)
+
+	if !reflect.DeepEqual(res, expected) {
+		fmt.Printf("%#v\n", res)
+		t.Fatal("Failed to correctly parse pairs")
+	}
+
 }


### PR DESCRIPTION
Hi Lev, please take a look. This fixes parsing URIs with embedded commas, which currently cause authentication failures in go-http-auth. Thanks, Kevin