### PR TITLE
fixes abbot/go-http-auth#21

### DIFF
--- a/digest.go
+++ b/digest.go
@@ -20,11 +20,11 @@ type digest_client struct {
 }
 
 type DigestAuth struct {
-	Realm                  string
-	Opaque                 string
-	Secrets                SecretProvider
-	PlainTextSecrets       bool
-	DisableNonceCountCheck bool
+	Realm            string
+	Opaque           string
+	Secrets          SecretProvider
+	PlainTextSecrets bool
+	IgnoreNonceCount bool
 
 	/*
 	   Approximate size of Client's Cache. When actual number of
@@ -165,7 +165,7 @@ func (da *DigestAuth) CheckAuth(r *http.Request) (username string, authinfo *str
 	if client, ok := da.clients[auth["nonce"]]; !ok {
 		return
 	} else {
-		if client.nc != 0 && client.nc >= nc && !da.DisableNonceCountCheck {
+		if client.nc != 0 && client.nc >= nc && !da.IgnoreNonceCount {
 			return
 		}
 		client.nc = nc

--- a/digest.go
+++ b/digest.go
@@ -20,10 +20,11 @@ type digest_client struct {
 }
 
 type DigestAuth struct {
-	Realm            string
-	Opaque           string
-	Secrets          SecretProvider
-	PlainTextSecrets bool
+	Realm                  string
+	Opaque                 string
+	Secrets                SecretProvider
+	PlainTextSecrets       bool
+	DisableNonceCountCheck bool
 
 	/*
 	   Approximate size of Client's Cache. When actual number of
@@ -164,7 +165,7 @@ func (da *DigestAuth) CheckAuth(r *http.Request) (username string, authinfo *str
 	if client, ok := da.clients[auth["nonce"]]; !ok {
 		return
 	} else {
-		if client.nc != 0 && client.nc >= nc {
+		if client.nc != 0 && client.nc >= nc && !da.DisableNonceCountCheck {
 			return
 		}
 		client.nc = nc

--- a/digest_test.go
+++ b/digest_test.go
@@ -40,11 +40,11 @@ func TestAuthDigest(t *testing.T) {
 	}
 
 	// try again with nc checking off
-	da.DisableNonceCountCheck = true
+	da.IgnoreNonceCount = true
 	if u, _ := da.CheckAuth(r); u != "test" {
 		t.Fatal("empty auth for outdated nc even though nc checking is off")
 	}
-	da.DisableNonceCountCheck = false
+	da.IgnoreNonceCount = false
 
 	r.URL, _ = url.Parse("/")
 	da.clients["Vb9BP/h81n3GpTTB"] = &digest_client{nc: 0, last_seen: time.Now().UnixNano()}

--- a/digest_test.go
+++ b/digest_test.go
@@ -33,9 +33,18 @@ func TestAuthDigest(t *testing.T) {
 	if u, _ := da.CheckAuth(r); u != "test" {
 		t.Fatal("empty auth for legitimate client")
 	}
+
+	// our nc is now 0, client nc is 1
 	if u, _ := da.CheckAuth(r); u != "" {
 		t.Fatal("non-empty auth for outdated nc")
 	}
+
+	// try again with nc checking off
+	da.DisableNonceCountCheck = true
+	if u, _ := da.CheckAuth(r); u != "test" {
+		t.Fatal("empty auth for outdated nc even though nc checking is off")
+	}
+	da.DisableNonceCountCheck = false
 
 	r.URL, _ = url.Parse("/")
 	da.clients["Vb9BP/h81n3GpTTB"] = &digest_client{nc: 0, last_seen: time.Now().UnixNano()}


### PR DESCRIPTION
Allows client to optionally disable nonce-count checking. Other servers that implements digest authentication (e.g. Apache, Squid) have similar options for doing this, so there is some precedent.

A related fix that could obviate disabling nc checking would be to remember all nc values seen and check new nc values against those, rather than assuming nc values always increase (since they don't!) However that would take more thought, as there are memory/performance implications. 
