### PR TITLE
Fix for Issue 23 - support proxy auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Features
 --------
  
  * Supports HTTP Basic and HTTP Digest authentication.
+ * Supports proxy authentication
  * Supports htpasswd and htdigest formatted files.
  * Automatic reloading of password files.
  * Pluggable interface for user/password storage.

--- a/auth.go
+++ b/auth.go
@@ -102,3 +102,35 @@ func JustCheck(auth AuthenticatorInterface, wrapped http.HandlerFunc) http.Handl
 		wrapped(w, &ar.Request)
 	})
 }
+
+func AuthenticateHeaderName(proxy bool) string {
+	if proxy {
+		return "Proxy-Authenticate"
+	}
+	return "WWW-Authenticate"
+}
+
+func AuthorizationHeaderName(proxy bool) string {
+	if proxy {
+		return "Proxy-Authorization"
+	}
+	return "Authorization"
+}
+
+func AuthenticationInfoHeaderName(proxy bool) string {
+	if proxy {
+		return "Proxy-Authentication-Info"
+	}
+	return "Authentication-Info"
+}
+
+func UnauthorizedStatusCode(proxy bool) int {
+	if proxy {
+		return http.StatusProxyAuthRequired
+	}
+	return http.StatusUnauthorized
+}
+
+func UnauthorizedStatusText(proxy bool) string {
+	return http.StatusText(UnauthorizedStatusCode(proxy))
+}

--- a/basic_test.go
+++ b/basic_test.go
@@ -8,33 +8,36 @@ import (
 
 func TestAuthBasic(t *testing.T) {
 	secrets := HtpasswdFileProvider("test.htpasswd")
-	a := &BasicAuth{Realm: "example.com", Secrets: secrets}
-	r := &http.Request{}
-	r.Method = "GET"
-	if a.CheckAuth(r) != "" {
-		t.Fatal("CheckAuth passed on empty headers")
-	}
-	r.Header = http.Header(make(map[string][]string))
-	r.Header.Set("Authorization", "Digest blabla ololo")
-	if a.CheckAuth(r) != "" {
-		t.Fatal("CheckAuth passed on bad headers")
-	}
-	r.Header.Set("Authorization", "Basic !@#")
-	if a.CheckAuth(r) != "" {
-		t.Fatal("CheckAuth passed on bad base64 data")
-	}
 
-	data := [][]string{
-		{"test", "hello"},
-		{"test2", "hello2"},
-		{"test3", "hello3"},
-		{"test16", "topsecret"},
-	}
-	for _, tc := range data {
-		auth := base64.StdEncoding.EncodeToString([]byte(tc[0] + ":" + tc[1]))
-		r.Header.Set("Authorization", "Basic "+auth)
-		if a.CheckAuth(r) != tc[0] {
-			t.Fatalf("CheckAuth failed for user '%s'", tc[0])
+	for _, isProxy := range []bool{false, true} {
+		a := &BasicAuth{IsProxy: isProxy, Realm: "example.com", Secrets: secrets}
+		r := &http.Request{}
+		r.Method = "GET"
+		if a.CheckAuth(r) != "" {
+			t.Fatal("CheckAuth passed on empty headers")
+		}
+		r.Header = http.Header(make(map[string][]string))
+		r.Header.Set(AuthorizationHeaderName(a.IsProxy), "Digest blabla ololo")
+		if a.CheckAuth(r) != "" {
+			t.Fatal("CheckAuth passed on bad headers")
+		}
+		r.Header.Set(AuthorizationHeaderName(a.IsProxy), "Basic !@#")
+		if a.CheckAuth(r) != "" {
+			t.Fatal("CheckAuth passed on bad base64 data")
+		}
+
+		data := [][]string{
+			{"test", "hello"},
+			{"test2", "hello2"},
+			{"test3", "hello3"},
+			{"test16", "topsecret"},
+		}
+		for _, tc := range data {
+			auth := base64.StdEncoding.EncodeToString([]byte(tc[0] + ":" + tc[1]))
+			r.Header.Set(AuthorizationHeaderName(a.IsProxy), "Basic "+auth)
+			if a.CheckAuth(r) != tc[0] {
+				t.Fatalf("CheckAuth failed for user '%s'", tc[0])
+			}
 		}
 	}
 }

--- a/digest.go
+++ b/digest.go
@@ -103,15 +103,7 @@ func DigestAuthParams(r *http.Request) map[string]string {
 		return nil
 	}
 
-	result := map[string]string{}
-	for _, kv := range strings.Split(s[1], ",") {
-		parts := strings.SplitN(kv, "=", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		result[strings.Trim(parts[0], "\" ")] = strings.Trim(parts[1], "\" ")
-	}
-	return result
+	return ParsePairs(s[1])
 }
 
 /*

--- a/digest_test.go
+++ b/digest_test.go
@@ -10,60 +10,64 @@ import (
 )
 
 func TestAuthDigest(t *testing.T) {
-	secrets := HtdigestFileProvider("test.htdigest")
-	da := &DigestAuth{Opaque: "U7H+ier3Ae8Skd/g",
-		Realm:   "example.com",
-		Secrets: secrets,
-		clients: map[string]*digest_client{}}
-	r := &http.Request{}
-	r.Method = "GET"
-	if u, _ := da.CheckAuth(r); u != "" {
-		t.Fatal("non-empty auth for empty request header")
-	}
-	r.Header = http.Header(make(map[string][]string))
-	r.Header.Set("Authorization", "Digest blabla")
-	if u, _ := da.CheckAuth(r); u != "" {
-		t.Fatal("non-empty auth for bad request header")
-	}
-	r.Header.Set("Authorization", `Digest username="test", realm="example.com", nonce="Vb9BP/h81n3GpTTB", uri="/t2", cnonce="NjE4MTM2", nc=00000001, qop="auth", response="ffc357c4eba74773c8687e0bc724c9a3", opaque="U7H+ier3Ae8Skd/g", algorithm="MD5"`)
-	if u, _ := da.CheckAuth(r); u != "" {
-		t.Fatal("non-empty auth for unknown client")
-	}
 
-	r.URL, _ = url.Parse("/t2")
-	da.clients["Vb9BP/h81n3GpTTB"] = &digest_client{nc: 0, last_seen: time.Now().UnixNano()}
-	if u, _ := da.CheckAuth(r); u != "test" {
-		t.Fatal("empty auth for legitimate client")
-	}
+	for _, isProxy := range []bool{false, true} {
+		secrets := HtdigestFileProvider("test.htdigest")
+		da := &DigestAuth{IsProxy: isProxy,
+			Opaque:  "U7H+ier3Ae8Skd/g",
+			Realm:   "example.com",
+			Secrets: secrets,
+			clients: map[string]*digest_client{}}
+		r := &http.Request{}
+		r.Method = "GET"
+		if u, _ := da.CheckAuth(r); u != "" {
+			t.Fatal("non-empty auth for empty request header")
+		}
+		r.Header = http.Header(make(map[string][]string))
+		r.Header.Set(AuthorizationHeaderName(da.IsProxy), "Digest blabla")
+		if u, _ := da.CheckAuth(r); u != "" {
+			t.Fatal("non-empty auth for bad request header")
+		}
+		r.Header.Set(AuthorizationHeaderName(da.IsProxy), `Digest username="test", realm="example.com", nonce="Vb9BP/h81n3GpTTB", uri="/t2", cnonce="NjE4MTM2", nc=00000001, qop="auth", response="ffc357c4eba74773c8687e0bc724c9a3", opaque="U7H+ier3Ae8Skd/g", algorithm="MD5"`)
+		if u, _ := da.CheckAuth(r); u != "" {
+			t.Fatal("non-empty auth for unknown client")
+		}
 
-	// our nc is now 0, client nc is 1
-	if u, _ := da.CheckAuth(r); u != "" {
-		t.Fatal("non-empty auth for outdated nc")
-	}
+		r.URL, _ = url.Parse("/t2")
+		da.clients["Vb9BP/h81n3GpTTB"] = &digest_client{nc: 0, last_seen: time.Now().UnixNano()}
+		if u, _ := da.CheckAuth(r); u != "test" {
+			t.Fatal("empty auth for legitimate client")
+		}
 
-	// try again with nc checking off
-	da.DisableNonceCountCheck = true
-	if u, _ := da.CheckAuth(r); u != "test" {
-		t.Fatal("empty auth for outdated nc even though nc checking is off")
-	}
-	da.DisableNonceCountCheck = false
+		// our nc is now 0, client nc is 1
+		if u, _ := da.CheckAuth(r); u != "" {
+			t.Fatal("non-empty auth for outdated nc")
+		}
 
-	r.URL, _ = url.Parse("/")
-	da.clients["Vb9BP/h81n3GpTTB"] = &digest_client{nc: 0, last_seen: time.Now().UnixNano()}
-	if u, _ := da.CheckAuth(r); u != "" {
-		t.Fatal("non-empty auth for bad request path")
-	}
+		// try again with nc checking off
+		da.DisableNonceCountCheck = true
+		if u, _ := da.CheckAuth(r); u != "test" {
+			t.Fatal("empty auth for outdated nc even though nc checking is off")
+		}
+		da.DisableNonceCountCheck = false
 
-	r.URL, _ = url.Parse("/t3")
-	da.clients["Vb9BP/h81n3GpTTB"] = &digest_client{nc: 0, last_seen: time.Now().UnixNano()}
-	if u, _ := da.CheckAuth(r); u != "" {
-		t.Fatal("non-empty auth for bad request path")
-	}
+		r.URL, _ = url.Parse("/")
+		da.clients["Vb9BP/h81n3GpTTB"] = &digest_client{nc: 0, last_seen: time.Now().UnixNano()}
+		if u, _ := da.CheckAuth(r); u != "" {
+			t.Fatal("non-empty auth for bad request path")
+		}
 
-	da.clients["+RbVXSbIoa1SaJk1"] = &digest_client{nc: 0, last_seen: time.Now().UnixNano()}
-	r.Header.Set("Authorization", `Digest username="test", realm="example.com", nonce="+RbVXSbIoa1SaJk1", uri="/", cnonce="NjE4NDkw", nc=00000001, qop="auth", response="c08918024d7faaabd5424654c4e3ad1c", opaque="U7H+ier3Ae8Skd/g", algorithm="MD5"`)
-	if u, _ := da.CheckAuth(r); u != "test" {
-		t.Fatal("empty auth for valid request in subpath")
+		r.URL, _ = url.Parse("/t3")
+		da.clients["Vb9BP/h81n3GpTTB"] = &digest_client{nc: 0, last_seen: time.Now().UnixNano()}
+		if u, _ := da.CheckAuth(r); u != "" {
+			t.Fatal("non-empty auth for bad request path")
+		}
+
+		da.clients["+RbVXSbIoa1SaJk1"] = &digest_client{nc: 0, last_seen: time.Now().UnixNano()}
+		r.Header.Set(AuthorizationHeaderName(da.IsProxy), `Digest username="test", realm="example.com", nonce="+RbVXSbIoa1SaJk1", uri="/", cnonce="NjE4NDkw", nc=00000001, qop="auth", response="c08918024d7faaabd5424654c4e3ad1c", opaque="U7H+ier3Ae8Skd/g", algorithm="MD5"`)
+		if u, _ := da.CheckAuth(r); u != "test" {
+			t.Fatal("empty auth for valid request in subpath")
+		}
 	}
 }
 
@@ -79,8 +83,9 @@ Authorization: Digest username="test", realm="", nonce="FRPnGdb8lvM1UHhi", uri="
 Connection: keep-alive
 
 `
+	da := &DigestAuth{}
 	req, _ := http.ReadRequest(bufio.NewReader(strings.NewReader(body)))
-	params := DigestAuthParams(req)
+	params := da.DigestAuthParams(req)
 	if params["uri"] != "/css?family=Source+Sans+Pro:400,700,400italic,700italic|Source+Code+Pro" {
 		t.Fatal("failed to parse uri with embedded commas")
 	}

--- a/digest_test.go
+++ b/digest_test.go
@@ -1,8 +1,10 @@
 package auth
 
 import (
+	"bufio"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 )
@@ -54,4 +56,24 @@ func TestAuthDigest(t *testing.T) {
 	if u, _ := da.CheckAuth(r); u != "test" {
 		t.Fatal("empty auth for valid request in subpath")
 	}
+}
+
+func TestDigestAuthParams(t *testing.T) {
+	body := `GET http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700,400italic,700italic|Source+Code+Pro HTTP/1.1
+Host: fonts.googleapis.com
+User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:43.0) Gecko/20100101 Firefox/43.0
+Accept: text/css,/;q=0.1
+Accept-Language: en-US,en;q=0.5
+Accept-Encoding: gzip, deflate
+Referer: http://elm-lang.org/assets/style.css
+Authorization: Digest username="test", realm="", nonce="FRPnGdb8lvM1UHhi", uri="/css?family=Source+Sans+Pro:400,700,400italic,700italic|Source+Code+Pro", algorithm=MD5, response="fdcdd78e5b306ffed343d0ec3967f2e5", opaque="lEgVjogmIar2fg/t", qop=auth, nc=00000001, cnonce="e76b05db27a3b323"
+Connection: keep-alive
+
+`
+	req, _ := http.ReadRequest(bufio.NewReader(strings.NewReader(body)))
+	params := DigestAuthParams(req)
+	if params["uri"] != "/css?family=Source+Sans+Pro:400,700,400italic,700italic|Source+Code+Pro" {
+		t.Fatal("failed to parse uri with embedded commas")
+	}
+
 }

--- a/misc.go
+++ b/misc.go
@@ -1,9 +1,13 @@
 package auth
 
-import "encoding/base64"
-import "crypto/md5"
-import "crypto/rand"
-import "fmt"
+import (
+	"bytes"
+	"crypto/md5"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"strings"
+)
 
 /*
  Return a random 16-byte base64 alphabet string
@@ -27,4 +31,70 @@ func H(data string) string {
 	digest := md5.New()
 	digest.Write([]byte(data))
 	return fmt.Sprintf("%x", digest.Sum(nil))
+}
+
+/*
+ ParseList parses a comma-separated list of values as described by RFC 2068.
+ which was itself ported from urllib2.parse_http_list, from the Python standard library.
+ Lifted from https://code.google.com/p/gorilla/source/browse/http/parser/parser.go
+*/
+func ParseList(value string) []string {
+	var list []string
+	var escape, quote bool
+	b := new(bytes.Buffer)
+	for _, r := range value {
+		if escape {
+			b.WriteRune(r)
+			escape = false
+			continue
+		}
+		if quote {
+			if r == '\\' {
+				escape = true
+				continue
+			} else if r == '"' {
+				quote = false
+			}
+			b.WriteRune(r)
+			continue
+		}
+		if r == ',' {
+			list = append(list, strings.TrimSpace(b.String()))
+			b.Reset()
+			continue
+		}
+		if r == '"' {
+			quote = true
+		}
+		b.WriteRune(r)
+	}
+	// Append last part.
+	if s := b.String(); s != "" {
+		list = append(list, strings.TrimSpace(s))
+	}
+	return list
+}
+
+/*
+ ParsePairs extracts key/value pairs from a comma-separated list of values as
+ described by RFC 2068.
+ The resulting values are unquoted. If a value doesn't contain a "=", the
+ key is the value itself and the value is an empty string.
+ Lifted from https://code.google.com/p/gorilla/source/browse/http/parser/parser.go
+*/
+func ParsePairs(value string) map[string]string {
+	m := make(map[string]string)
+	for _, pair := range ParseList(strings.TrimSpace(value)) {
+		if i := strings.Index(pair, "="); i < 0 {
+			m[pair] = ""
+		} else {
+			v := pair[i+1:]
+			if v[0] == '"' && v[len(v)-1] == '"' {
+				// Unquote it.
+				v = v[1 : len(v)-1]
+			}
+			m[pair[:i]] = v
+		}
+	}
+	return m
 }

--- a/misc_test.go
+++ b/misc_test.go
@@ -1,6 +1,10 @@
 package auth
 
-import "testing"
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
 
 func TestH(t *testing.T) {
 	const hello = "Hello, world!"
@@ -9,4 +13,29 @@ func TestH(t *testing.T) {
 	if h != hello_md5 {
 		t.Fatal("Incorrect digest for test string:", h, "instead of", hello_md5)
 	}
+}
+
+func TestParsePairs(t *testing.T) {
+	const header = `username="test", realm="", nonce="FRPnGdb8lvM1UHhi", uri="/css?family=Source+Sans+Pro:400,700,400italic,700italic|Source+Code+Pro", algorithm=MD5, response="fdcdd78e5b306ffed343d0ec3967f2e5", opaque="lEgVjogmIar2fg/t", qop=auth, nc=00000001, cnonce="e76b05db27a3b323"`
+
+	expected := map[string]string{
+		"username":  "test",
+		"realm":     "",
+		"nonce":     "FRPnGdb8lvM1UHhi",
+		"uri":       "/css?family=Source+Sans+Pro:400,700,400italic,700italic|Source+Code+Pro",
+		"algorithm": "MD5",
+		"response":  "fdcdd78e5b306ffed343d0ec3967f2e5",
+		"opaque":    "lEgVjogmIar2fg/t",
+		"qop":       "auth",
+		"nc":        "00000001",
+		"cnonce":    "e76b05db27a3b323",
+	}
+
+	res := ParsePairs(header)
+
+	if !reflect.DeepEqual(res, expected) {
+		fmt.Printf("%#v\n", res)
+		t.Fatal("Failed to correctly parse pairs")
+	}
+
 }


### PR DESCRIPTION
This PR adds support for using go-http-auth within a proxy server, which requires the use of different header names. Note this PR also includes the fixes for #21 and #22. 
