### PR TITLE
remove unneeded package name in import

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This is a complete working example for Basic auth:
     package main
 
     import (
-            auth "github.com/abbot/go-http-auth"
+            "github.com/abbot/go-http-auth"
             "fmt"
             "net/http"
     )


### PR DESCRIPTION
"auth" is not needed since the package name is already "auth"