### PR TITLE
Fixed detection of bcrypt prefixes

### DIFF
--- a/basic.go
+++ b/basic.go
@@ -24,6 +24,8 @@ var (
 	}{
 		{"", compareMD5HashAndPassword}, // default compareFunc
 		{"{SHA}", compareShaHashAndPassword},
+		{"$2a$", bcrypt.CompareHashAndPassword},
+		{"$2b$", bcrypt.CompareHashAndPassword},
 		{"$2y$", bcrypt.CompareHashAndPassword},
 	}
 )


### PR DESCRIPTION
The original code only detected the prefix "$2y$", but "$2a$" and "$2b$" are also valid.
See https://en.wikipedia.org/wiki/Bcrypt.