### PR TITLE
Keep original request

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -11,7 +11,7 @@ import (
  Request handlers must take AuthenticatedRequest instead of http.Request
 */
 type AuthenticatedRequest struct {
-	http.Request
+	*http.Request
 	/*
 	 Authenticated user name. Current API implies that Username is
 	 never empty, which means that authentication is always done

--- a/basic.go
+++ b/basic.go
@@ -142,7 +142,7 @@ func (a *BasicAuth) Wrap(wrapped AuthenticatedHandlerFunc) http.HandlerFunc {
 		if username := a.CheckAuth(r); username == "" {
 			a.RequireAuth(w, r)
 		} else {
-			ar := &AuthenticatedRequest{Request: *r, Username: username}
+			ar := &AuthenticatedRequest{Request: r, Username: username}
 			wrapped(w, ar)
 		}
 	}

--- a/digest.go
+++ b/digest.go
@@ -219,7 +219,7 @@ func (a *DigestAuth) Wrap(wrapped AuthenticatedHandlerFunc) http.HandlerFunc {
 		if username, authinfo := a.CheckAuth(r); username == "" {
 			a.RequireAuth(w, r)
 		} else {
-			ar := &AuthenticatedRequest{Request: *r, Username: username}
+			ar := &AuthenticatedRequest{Request: r, Username: username}
 			if authinfo != nil {
 				w.Header().Set(a.Headers.V().AuthInfo, *authinfo)
 			}


### PR DESCRIPTION
Before a copy was used, this patch
uses the original request can be useful
in case of using gorilla as it keeps
a context thanks to the pointer of the
request.