### PR TITLE
Fixed concurrent map read and map write in default secret providers (issue crashes web server)

### DIFF
--- a/users_test.go
+++ b/users_test.go
@@ -1,7 +1,9 @@
 package auth
 
 import (
+	"os"
 	"testing"
+	"time"
 )
 
 func TestHtdigestFile(t *testing.T) {
@@ -30,4 +32,14 @@ func TestHtpasswdFile(t *testing.T) {
 	if passwd != "" {
 		t.Fatal("Got passwd for non-existant user:", passwd)
 	}
+}
+
+// TestConcurrent verifies potential race condition in users reading logic
+func TestConcurrent(t *testing.T) {
+	secrets := HtpasswdFileProvider("test.htpasswd")
+	os.Chtimes("test.htpasswd", time.Now(), time.Now())
+	go func() {
+		secrets("test", "blah")
+	}()
+	secrets("test", "blah")
 }


### PR DESCRIPTION
Getting the following stacktrace when replacing htpasswd file during server run:
```
fatal error: concurrent map read and map write

goroutine 6472875 [running]:
runtime.throw(0x6d07a9, 0x21)
	/usr/lib/go-1.7/src/runtime/panic.go:566 +0x95 fp=0xc420501ad0 sp=0xc420501ab0
runtime.mapaccess2_faststr(0x67a560, 0xc4200a7980, 0xc4202e3040, 0x9, 0xc4202e3080, 0x2)
	/usr/lib/go-1.7/src/runtime/hashmap_fast.go:306 +0x52b fp=0xc420501b30 sp=0xc420501ad0
github.com/abbot/go-http-auth.HtpasswdFileProvider.func2(0xc4202e3040, 0x9, 0x6cbc3b, 0x14, 0x2, 0xc4202e3080)
	/root/vania-pooh/go/src/github.com/abbot/go-http-auth/users.go:132 +0x67 fp=0xc420501b78 sp=0xc420501b30
github.com/abbot/go-http-auth.(*BasicAuth).CheckAuth(0xc4203d3cc0, 0xc42010e1e0, 0xc4203deb70, 0xc4202a6030)
	/root/vania-pooh/go/src/github.com/abbot/go-http-auth/basic.go:83 +0x1ee fp=0xc420501c30 sp=0xc420501b78
github.com/abbot/go-http-auth.(*BasicAuth).Wrap.func1(0x7eaf00, 0xc4204e8b60, 0xc42010e1e0)
	/root/vania-pooh/go/src/github.com/abbot/go-http-auth/basic.go:142 +0x46 fp=0xc420501c88 sp=0xc420501c30
net/http.HandlerFunc.ServeHTTP(0xc4203d3d60, 0x7eaf00, 0xc4204e8b60, 0xc42010e1e0)
	/usr/lib/go-1.7/src/net/http/server.go:1726 +0x44 fp=0xc420501cb0 sp=0xc420501c88
net/http.(*ServeMux).ServeHTTP(0xc42029a0c0, 0x7eaf00, 0xc4204e8b60, 0xc42010e1e0)
	/usr/lib/go-1.7/src/net/http/server.go:2022 +0x7f fp=0xc420501cf0 sp=0xc420501cb0
net/http.serverHandler.ServeHTTP(0xc42005e880, 0x7eaf00, 0xc4204e8b60, 0xc42010e1e0)
	/usr/lib/go-1.7/src/net/http/server.go:2202 +0x7d fp=0xc420501d38 sp=0xc420501cf0
net/http.(*conn).serve(0xc4200f5880, 0x7eb440, 0xc420184c00)
	/usr/lib/go-1.7/src/net/http/server.go:1579 +0x4b7 fp=0xc420501f98 sp=0xc420501d38
runtime.goexit()
	/usr/lib/go-1.7/src/runtime/asm_amd64.s:2086 +0x1 fp=0xc420501fa0 sp=0xc420501f98
created by net/http.(*Server).Serve
	/usr/lib/go-1.7/src/net/http/server.go:2293 +0x44d
```
Added RWLock where necessary.