### PR TITLE
use http.Handler interface instead of HandlerFunc

### DIFF
--- a/basic.go
+++ b/basic.go
@@ -132,20 +132,20 @@ func (a *BasicAuth) RequireAuth(w http.ResponseWriter, r *http.Request) {
 
 /*
  BasicAuthenticator returns a function, which wraps an
- AuthenticatedHandlerFunc converting it to http.HandlerFunc. This
+ AuthenticatedHandlerFunc converting it to http.Handler. This
  wrapper function checks the authentication and either sends back
  required authentication headers, or calls the wrapped function with
  authenticated username in the AuthenticatedRequest.
 */
-func (a *BasicAuth) Wrap(wrapped AuthenticatedHandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+func (a *BasicAuth) Wrap(wrapped AuthenticatedHandlerFunc) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if username := a.CheckAuth(r); username == "" {
 			a.RequireAuth(w, r)
 		} else {
 			ar := &AuthenticatedRequest{Request: *r, Username: username}
 			wrapped(w, ar)
 		}
-	}
+	})
 }
 
 // NewContext returns a context carrying authentication information for the request.

--- a/digest.go
+++ b/digest.go
@@ -214,8 +214,8 @@ const DefaultClientCacheTolerance = 100
  secrets: SecretProvider which must return HA1 digests for the same
  realm as above.
 */
-func (a *DigestAuth) Wrap(wrapped AuthenticatedHandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+func (a *DigestAuth) Wrap(wrapped AuthenticatedHandlerFunc) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if username, authinfo := a.CheckAuth(r); username == "" {
 			a.RequireAuth(w, r)
 		} else {
@@ -225,18 +225,18 @@ func (a *DigestAuth) Wrap(wrapped AuthenticatedHandlerFunc) http.HandlerFunc {
 			}
 			wrapped(w, ar)
 		}
-	}
+	})
 }
 
 /*
- JustCheck returns function which converts an http.HandlerFunc into a
- http.HandlerFunc which requires authentication. Username is passed as
+ JustCheck returns function which converts an http.Handler into a
+ http.Handler which requires authentication. Username is passed as
  an extra X-Authenticated-Username header.
 */
-func (a *DigestAuth) JustCheck(wrapped http.HandlerFunc) http.HandlerFunc {
+func (a *DigestAuth) JustCheck(wrapped http.Handler) http.Handler {
 	return a.Wrap(func(w http.ResponseWriter, ar *AuthenticatedRequest) {
 		ar.Header.Set(AuthUsernameHeader, ar.Username)
-		wrapped(w, &ar.Request)
+		wrapped.ServeHTTP(w, &ar.Request)
 	})
 }
 

--- a/examples/basic.go
+++ b/examples/basic.go
@@ -30,6 +30,6 @@ func handle(w http.ResponseWriter, r *auth.AuthenticatedRequest) {
 
 func main() {
 	authenticator := auth.NewBasicAuthenticator("example.com", Secret)
-	http.HandleFunc("/", authenticator.Wrap(handle))
+	http.Handle("/", authenticator.Wrap(handle))
 	http.ListenAndServe(":8080", nil)
 }

--- a/examples/digest.go
+++ b/examples/digest.go
@@ -30,6 +30,6 @@ func handle(w http.ResponseWriter, r *auth.AuthenticatedRequest) {
 
 func main() {
 	authenticator := auth.NewDigestAuthenticator("example.com", Secret)
-	http.HandleFunc("/", authenticator.Wrap(handle))
+	http.Handle("/", authenticator.Wrap(handle))
 	http.ListenAndServe(":8080", nil)
 }

--- a/examples/wrapped.go
+++ b/examples/wrapped.go
@@ -25,12 +25,13 @@ func Secret(user, realm string) string {
 	return ""
 }
 
-func regular_handler(w http.ResponseWriter, r *http.Request) {
+func regularHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "<html><body><h1>This application is unaware of authentication</h1></body></html>")
 }
 
 func main() {
 	authenticator := auth.NewBasicAuthenticator("example.com", Secret)
-	http.HandleFunc("/", auth.JustCheck(authenticator, regular_handler))
+	handler := http.HandlerFunc(regularHandler)
+	http.Handle("/", auth.JustCheck(authenticator, handler))
 	http.ListenAndServe(":8080", nil)
 }


### PR DESCRIPTION
This helps the package fit better with a lot of middleware (e.g. [goji](https://godoc.org/goji.io#Mux.Use)).