### PR TITLE
Replace golang.org/x/net/context by context.

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -2,9 +2,8 @@
 package auth
 
 import (
+	"context"
 	"net/http"
-
-	"golang.org/x/net/context"
 )
 
 // AuthenticatedRequest is passed to AuthenticatedHandlerFunc instead

--- a/basic.go
+++ b/basic.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha1"
 	"crypto/subtle"
 	"encoding/base64"
@@ -10,7 +11,6 @@ import (
 	"strings"
 
 	"golang.org/x/crypto/bcrypt"
-	"golang.org/x/net/context"
 )
 
 type compareFunc func(hashedPassword, password []byte) error

--- a/digest.go
+++ b/digest.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"crypto/subtle"
 	"fmt"
 	"net/http"
@@ -10,8 +11,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 type digestClient struct {

--- a/examples/context.go
+++ b/examples/context.go
@@ -11,11 +11,11 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
 	auth ".."
-	"golang.org/x/net/context"
 )
 
 func secret(user, realm string) string {


### PR DESCRIPTION
Use `go fix` to replace `golang.org/x/net/context` by `context`.