### PR TITLE
chore: use go module.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,19 @@
 arch:
   - amd64
   - ppc64le
-sudo: false
+
 language: go
 go:
-  - 1.8.x
-  - 1.11.x
+  - 1.15.x
+  - 1.16.x
   - master
-  
+
+env:
+  global:
+    - GO111MODULE=on
+
 install:
-  - go get -t -v ./...
+  - go mod download
 
 script:
   - go test -v -race ./...
@@ -18,6 +22,3 @@ matrix:
   allow_failures:
     - go: master
   fast_finish: true
-  exclude:
-  - arch: ppc64le
-    go: 1.8.x

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/abbot/go-http-auth
+
+go 1.11
+
+require golang.org/x/crypto v0.0.0-20200317142112-1b76d66859c6

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200317142112-1b76d66859c6 h1:TjszyFsQsyZNHwdVdZ5m7bjmreu0znc2kRYsEml9/Ww=
+golang.org/x/crypto v0.0.0-20200317142112-1b76d66859c6/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
I propose you to migrate to go module.

With go 1.13 the go modules will be the default.

Fixes #47 
