### PR TITLE
Add check on cache length when purging entries

### DIFF
--- a/digest.go
+++ b/digest.go
@@ -80,7 +80,13 @@ func (da *DigestAuth) Purge(count int) {
 	}
 	cache := digestCache(entries)
 	sort.Sort(cache)
-	for _, client := range cache[:count] {
+
+	limit := count
+	if len(cache) < count {
+		limit = len(cache) - 1
+	}
+
+	for _, client := range cache[:limit] {
 		delete(da.clients, client.nonce)
 	}
 }


### PR DESCRIPTION
When the authenticator's cache is purged, there was a consistent `slice bounds out of range [:200] with capacity 181` panic occurring. Checking that the `count` variable here does not exceed the actual length of the cache should avoid this panic when the cache is purged.