### PR TITLE
Modify cache purging limit

### DIFF
--- a/digest.go
+++ b/digest.go
@@ -80,7 +80,13 @@ func (da *DigestAuth) Purge(count int) {
 	}
 	cache := digestCache(entries)
 	sort.Sort(cache)
-	for _, client := range cache[:count] {
+
+	limit := count
+	if len(cache) < count {
+		limit = len(cache) - 1
+	}
+
+	for _, client := range cache[:limit] {
 		delete(da.clients, client.nonce)
 	}
 }

--- a/digest.go
+++ b/digest.go
@@ -81,12 +81,7 @@ func (da *DigestAuth) Purge(count int) {
 	cache := digestCache(entries)
 	sort.Sort(cache)
 
-	limit := count
-	if len(cache) < count {
-		limit = len(cache) - 1
-	}
-
-	for _, client := range cache[:limit] {
+	for _, client := range cache {
 		delete(da.clients, client.nonce)
 	}
 }


### PR DESCRIPTION
When the authenticator's cache is purged, there was a consistent `slice bounds out of range [:200] with capacity 181` panic occurring. Purging the entire cache resolves this error. 

This is moved over from https://github.com/abbot/go-http-auth/pull/68, which is closed.