### PR TITLE
fix: avoid panic when parsing pairs

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -81,7 +81,7 @@ func ParseList(value string) []string {
 func ParsePairs(value string) map[string]string {
 	m := make(map[string]string)
 	for _, pair := range ParseList(strings.TrimSpace(value)) {
-		if i := strings.Index(pair, "="); i < 0 {
+		if i := strings.Index(pair, "="); i < 0 || i == len(pair)-1{
 			m[pair] = ""
 		} else {
 			v := pair[i+1:]


### PR DESCRIPTION
This PR fixes a panic that occurs when pairs with empty value written as `name=` instead of
`name=""`.